### PR TITLE
Tighten instructor scoped workflows

### DIFF
--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -1,0 +1,73 @@
+# User Journeys & Data Flow
+
+This document summarises the end-to-end experience for teachers and students in **SchoolOS**, highlighting the data models and API touchpoints involved at each step. It reflects the tightened access controls introduced in this change-set to keep the workflows simple and predictable.
+
+## Core Entities
+
+- **User** – stored in `users` collection with role (`admin`, `teacher`, `student`) and status flags.
+- **Programme & Cohort** – academic structures created by administrators; cohorts group classes by intake.
+- **Class** – owned by a cohort, referenced by `ClassEntity` with an immutable `code` and an array of `instructorIds`.
+- **Enrollment** – junction between a class and a student, tracking status (`active`, `completed`, `dropped`).
+- **Assignment** – tasks tied to a class with schedule metadata (publish/due dates, grading schema).
+- **Grade** – per-assignment record for an enrolled student with history trail and release status.
+
+These entities are linked strictly through IDs, keeping the data model lean while enforcing role-based permissions at the service layer.
+
+## Teacher Journey
+
+1. **Authenticate**
+   - Request: `POST /api/auth/login`
+   - Response returns JWT + teacher profile. Token gate-keeps all protected routes.
+
+2. **View Assigned Classes**
+   - Request: `GET /api/classes`
+   - Server auto-filters by `instructorIds` for the calling teacher, returning only their active classes along with codes and scheduling metadata.
+
+3. **Inspect Roster**
+   - Request: `GET /api/classes/:classId/enrollments`
+   - Guard validates the teacher is assigned to the class before returning enrollments enriched with student directory info.
+
+4. **Enroll a Student**
+   - Request: `POST /api/classes/:classId/enrollments`
+   - Payload accepts either `studentId` or `studentEmail`. The controller reuses the instructor guard to keep enrolments scoped to owned classes.
+
+5. **Publish Assignments**
+   - Request: `POST /api/classes/:classId/assignments`
+   - Teachers can only create assignments for classes they teach; `ClassesService.ensureInstructorAccess` verifies ownership before persisting the record.
+
+6. **Track Assignment List**
+   - Request: `GET /api/classes/:classId/assignments`
+   - Returns chronological list for UI dashboards (e.g. upcoming due date widgets).
+
+7. **Grade Submissions**
+   - Request: `POST /api/assignments/:assignmentId/grades`
+   - Service verifies: (a) assignment exists, (b) student belongs to the class, and (c) instructor owns the class. Grade history captures author + timestamp for audit.
+
+8. **Release Grades**
+   - Request: `POST /api/grades/:gradeId/release`
+   - Ownership check ensures teachers can only release grades for their classes. Release triggers NotificationsService to inform students.
+
+## Student Journey
+
+1. **Authenticate**
+   - Request: `POST /api/auth/login`
+   - Returns JWT + profile (role = `student`).
+
+2. **See Personal Assignment Feed**
+   - Request: `GET /api/students/:studentId/assignments`
+   - Guard ensures students can only access their own ID. Response merges assignments from enrolled classes with grade status, due dates, and feedback.
+
+3. **Review Grades**
+   - Request: `GET /api/students/:studentId/grades`
+   - Provides the grade ledger for transcripts and historical context.
+
+4. **Class Visibility (Optional)**
+   - A student’s classes are implicit via enrolments surfaced in assignment data. Additional roster visibility can be added later if needed, but the streamlined view keeps the dashboard focused on what matters now: upcoming work and released feedback.
+
+## Structural Improvements Introduced
+
+- **Instructor-scoped operations** – Teachers can now only list classes, manage enrolments, publish assignments, and adjust grades for classes they own. This keeps the workflow focused and prevents accidental cross-class edits.
+- **Shared guard helper** – `ClassesService.ensureInstructorAccess` centralises the access rule so assignments and grades reuse the same logic, reducing drift.
+- **Documented journey** – This page provides a canonical flow reference for onboarding and future product work.
+
+These changes ensure teachers and students land in purpose-built workspaces that only surface the data they own, reinforcing a “dead simple” experience without compromising data boundaries.

--- a/server/src/modules/assignments/assignments.controller.ts
+++ b/server/src/modules/assignments/assignments.controller.ts
@@ -6,6 +6,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { UserRole } from '../users/schemas/user.schema';
+import { CurrentUser, RequestUser } from '../auth/current-user.decorator';
 
 @Controller()
 export class AssignmentsController {
@@ -14,8 +15,16 @@ export class AssignmentsController {
   @Post('classes/:classId/assignments')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.Admin, UserRole.Teacher)
-  createAssignment(@Param('classId') classId: string, @Body() dto: CreateAssignmentDto) {
-    return this.assignmentsService.create(classId, dto);
+  createAssignment(
+    @Param('classId') classId: string,
+    @Body() dto: CreateAssignmentDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    const options =
+      user.role === UserRole.Teacher
+        ? { restrictToInstructorId: user.userId }
+        : undefined;
+    return this.assignmentsService.create(classId, dto, options);
   }
 
   @Get('classes/:classId/assignments')
@@ -33,7 +42,15 @@ export class AssignmentsController {
   @Patch('assignments/:id')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.Admin, UserRole.Teacher)
-  updateAssignment(@Param('id') id: string, @Body() dto: UpdateAssignmentDto) {
-    return this.assignmentsService.update(id, dto);
+  updateAssignment(
+    @Param('id') id: string,
+    @Body() dto: UpdateAssignmentDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    const options =
+      user.role === UserRole.Teacher
+        ? { restrictToInstructorId: user.userId }
+        : undefined;
+    return this.assignmentsService.update(id, dto, options);
   }
 }

--- a/server/src/modules/classes/classes.controller.ts
+++ b/server/src/modules/classes/classes.controller.ts
@@ -20,14 +20,15 @@ export class ClassesController {
   }
 
   @Get()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.Admin, UserRole.Teacher)
   listClasses(
     @CurrentUser() user: RequestUser,
     @Query('cohortId') cohortId?: string,
     @Query('instructorId') instructorId?: string,
   ) {
     const filters: Record<string, string | undefined> = { cohortId };
-    if (user?.role === UserRole.Teacher && !instructorId) {
+    if (user.role === UserRole.Teacher) {
       filters.instructorId = user.userId;
     } else if (instructorId) {
       filters.instructorId = instructorId;
@@ -44,13 +45,26 @@ export class ClassesController {
   @Post(':id/enrollments')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.Admin, UserRole.Teacher)
-  enrollStudent(@Param('id') classId: string, @Body() dto: EnrollStudentDto) {
-    return this.classesService.enrollStudent(classId, dto);
+  enrollStudent(
+    @Param('id') classId: string,
+    @Body() dto: EnrollStudentDto,
+    @CurrentUser() user: RequestUser,
+  ) {
+    const options =
+      user.role === UserRole.Teacher
+        ? { restrictToInstructorId: user.userId }
+        : undefined;
+    return this.classesService.enrollStudent(classId, dto, options);
   }
 
   @Get(':id/enrollments')
-  @UseGuards(JwtAuthGuard)
-  listEnrollments(@Param('id') classId: string) {
-    return this.classesService.listEnrollments(classId);
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.Admin, UserRole.Teacher)
+  listEnrollments(@Param('id') classId: string, @CurrentUser() user: RequestUser) {
+    const options =
+      user.role === UserRole.Teacher
+        ? { restrictToInstructorId: user.userId }
+        : undefined;
+    return this.classesService.listEnrollments(classId, options);
   }
 }

--- a/server/src/modules/classes/classes.service.ts
+++ b/server/src/modules/classes/classes.service.ts
@@ -1,5 +1,6 @@
 import {
   ConflictException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -69,8 +70,27 @@ export class ClassesService {
     return record;
   }
 
-  async enrollStudent(classId: string, dto: EnrollStudentDto) {
-    await this.getClassById(classId);
+  async ensureInstructorAccess(classId: string, instructorId: string) {
+    const classRecord = await this.getClassById(classId);
+    const instructorIds = (classRecord.instructorIds ?? []).map((id: any) =>
+      typeof id === 'string' ? id : id.toString(),
+    );
+    if (!instructorIds.includes(instructorId)) {
+      throw new ForbiddenException('You are not assigned to this class');
+    }
+    return classRecord;
+  }
+
+  async enrollStudent(
+    classId: string,
+    dto: EnrollStudentDto,
+    options: { restrictToInstructorId?: string } = {},
+  ) {
+    if (options.restrictToInstructorId) {
+      await this.ensureInstructorAccess(classId, options.restrictToInstructorId);
+    } else {
+      await this.getClassById(classId);
+    }
 
     let studentId = dto.studentId;
     if (!studentId && dto.studentEmail) {
@@ -99,8 +119,15 @@ export class ClassesService {
     return enrollment;
   }
 
-  async listEnrollments(classId: string) {
-    await this.getClassById(classId);
+  async listEnrollments(
+    classId: string,
+    options: { restrictToInstructorId?: string } = {},
+  ) {
+    if (options.restrictToInstructorId) {
+      await this.ensureInstructorAccess(classId, options.restrictToInstructorId);
+    } else {
+      await this.getClassById(classId);
+    }
     const enrollments = await this.enrollmentModel.find({ classId }).lean().exec();
     if (!enrollments.length) {
       return [];

--- a/server/src/modules/grades/grades.controller.ts
+++ b/server/src/modules/grades/grades.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Post, UseGuards, ForbiddenException } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+  ForbiddenException,
+} from '@nestjs/common';
 import { GradesService } from './grades.service';
 import { ReleaseGradeDto } from './dto/release-grade.dto';
 import { UpsertGradeDto } from './dto/upsert-grade.dto';
@@ -66,18 +74,46 @@ export class GradesController {
   @Get('students/:studentId/grades')
   @UseGuards(JwtAuthGuard)
   getStudentGrades(@Param('studentId') studentId: string, @CurrentUser() user: RequestUser) {
-    if (user.role === UserRole.Student && user.userId !== studentId) {
-      throw new ForbiddenException('Cannot view other students grades');
-    }
-    return this.gradesService.listGradesForStudent(studentId);
+    const targetStudentId = this.resolveStudentId(studentId, user, 'grades');
+    return this.gradesService.listGradesForStudent(targetStudentId);
+  }
+
+  @Get('students/me/grades')
+  @UseGuards(JwtAuthGuard)
+  getCurrentStudentGrades(@CurrentUser() user: RequestUser) {
+    return this.gradesService.listGradesForStudent(this.ensureStudentRole(user));
   }
 
   @Get('students/:studentId/assignments')
   @UseGuards(JwtAuthGuard)
-  getStudentAssignments(@Param('studentId') studentId: string, @CurrentUser() user: RequestUser) {
-    if (user.role === UserRole.Student && user.userId !== studentId) {
-      throw new ForbiddenException('Cannot view other students assignments');
+  getStudentAssignments(
+    @Param('studentId') studentId: string,
+    @CurrentUser() user: RequestUser,
+  ) {
+    const targetStudentId = this.resolveStudentId(studentId, user, 'assignments');
+    return this.gradesService.getStudentAssignmentOverview(targetStudentId);
+  }
+
+  @Get('students/me/assignments')
+  @UseGuards(JwtAuthGuard)
+  getCurrentStudentAssignments(@CurrentUser() user: RequestUser) {
+    return this.gradesService.getStudentAssignmentOverview(this.ensureStudentRole(user));
+  }
+
+  private resolveStudentId(pathStudentId: string, user: RequestUser, resource: string) {
+    if (user.role === UserRole.Student) {
+      if (user.userId !== pathStudentId) {
+        throw new ForbiddenException(`Cannot view other students ${resource}`);
+      }
+      return user.userId;
     }
-    return this.gradesService.getStudentAssignmentOverview(studentId);
+    return pathStudentId;
+  }
+
+  private ensureStudentRole(user: RequestUser) {
+    if (user.role !== UserRole.Student) {
+      throw new ForbiddenException('Only students can access their own shortcut routes');
+    }
+    return user.userId;
   }
 }

--- a/server/src/modules/grades/grades.controller.ts
+++ b/server/src/modules/grades/grades.controller.ts
@@ -20,14 +20,25 @@ export class GradesController {
     @Body() dto: UpsertGradeDto,
     @CurrentUser() user: RequestUser,
   ) {
-    return this.gradesService.upsertGrade(assignmentId, { ...dto, actorId: user.userId });
+    const options =
+      user.role === UserRole.Teacher
+        ? { restrictToInstructorId: user.userId }
+        : undefined;
+    return this.gradesService.upsertGrade(assignmentId, { ...dto, actorId: user.userId }, options);
   }
 
   @Get('assignments/:assignmentId/grades')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.Admin, UserRole.Teacher)
-  listGrades(@Param('assignmentId') assignmentId: string) {
-    return this.gradesService.listGradesForAssignment(assignmentId);
+  listGrades(
+    @Param('assignmentId') assignmentId: string,
+    @CurrentUser() user: RequestUser,
+  ) {
+    const options =
+      user.role === UserRole.Teacher
+        ? { restrictToInstructorId: user.userId }
+        : undefined;
+    return this.gradesService.listGradesForAssignment(assignmentId, options);
   }
 
   @Post('grades/:gradeId/release')
@@ -38,10 +49,18 @@ export class GradesController {
     @Body() dto: ReleaseGradeDto,
     @CurrentUser() user: RequestUser,
   ) {
-    return this.gradesService.releaseGrade(gradeId, {
-      ...dto,
-      actorId: user.userId,
-    });
+    const options =
+      user.role === UserRole.Teacher
+        ? { restrictToInstructorId: user.userId }
+        : undefined;
+    return this.gradesService.releaseGrade(
+      gradeId,
+      {
+        ...dto,
+        actorId: user.userId,
+      },
+      options,
+    );
   }
 
   @Get('students/:studentId/grades')

--- a/server/src/modules/grades/grades.module.ts
+++ b/server/src/modules/grades/grades.module.ts
@@ -5,6 +5,7 @@ import { Assignment, AssignmentSchema } from '../assignments/schemas/assignment.
 import { Enrollment, EnrollmentSchema } from '../classes/schemas/enrollment.schema';
 import { UsersModule } from '../users/users.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { ClassEntity, ClassSchema } from '../classes/schemas/class.schema';
 import { GradesController } from './grades.controller';
 import { GradesService } from './grades.service';
 import { Grade, GradeSchema } from './schemas/grade.schema';
@@ -15,6 +16,7 @@ import { Grade, GradeSchema } from './schemas/grade.schema';
       { name: Grade.name, schema: GradeSchema },
       { name: Assignment.name, schema: AssignmentSchema },
       { name: Enrollment.name, schema: EnrollmentSchema },
+      { name: ClassEntity.name, schema: ClassSchema },
     ]),
     AssignmentsModule,
     UsersModule,

--- a/server/src/modules/grades/grades.service.ts
+++ b/server/src/modules/grades/grades.service.ts
@@ -4,6 +4,7 @@ import { Model, isValidObjectId } from 'mongoose';
 import { AssignmentsService } from '../assignments/assignments.service';
 import { Assignment, AssignmentDocument } from '../assignments/schemas/assignment.schema';
 import { Enrollment, EnrollmentDocument } from '../classes/schemas/enrollment.schema';
+import { ClassEntity, ClassDocument } from '../classes/schemas/class.schema';
 import { UsersService } from '../users/users.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { ReleaseGradeDto } from './dto/release-grade.dto';
@@ -19,6 +20,8 @@ export class GradesService {
     private readonly assignmentModel: Model<AssignmentDocument>,
     @InjectModel(Enrollment.name)
     private readonly enrollmentModel: Model<EnrollmentDocument>,
+    @InjectModel(ClassEntity.name)
+    private readonly classModel: Model<ClassDocument>,
     private readonly assignmentsService: AssignmentsService,
     private readonly usersService: UsersService,
     private readonly notificationsService: NotificationsService,
@@ -82,29 +85,68 @@ export class GradesService {
     assignmentId: string,
     options: { restrictToInstructorId?: string } = {},
   ) {
-    if (options.restrictToInstructorId) {
-      await this.assignmentsService.ensureInstructorAccess(
-        assignmentId,
-        options.restrictToInstructorId,
-      );
-    } else {
-      await this.assignmentsService.findById(assignmentId);
-    }
-    const grades = await this.gradeModel.find({ assignmentId }).lean().exec();
-    if (!grades.length) {
+    const assignment = options.restrictToInstructorId
+      ? await this.assignmentsService.ensureInstructorAccess(
+          assignmentId,
+          options.restrictToInstructorId,
+        )
+      : await this.assignmentsService.findById(assignmentId);
+
+    const [grades, enrollments] = await Promise.all([
+      this.gradeModel.find({ assignmentId }).lean().exec(),
+      this.enrollmentModel
+        .find({ classId: assignment.classId })
+        .lean()
+        .exec(),
+    ]);
+
+    const enrollmentByStudentId = new Map(
+      enrollments.map((enrollment) => [
+        enrollment.studentId.toString(),
+        enrollment,
+      ]),
+    );
+
+    const gradeByStudentId = new Map(
+      grades.map((grade) => [grade.studentId.toString(), grade]),
+    );
+
+    const allStudentIds = new Set<string>();
+    enrollments.forEach((enrollment) =>
+      allStudentIds.add(enrollment.studentId.toString()),
+    );
+    grades.forEach((grade) => allStudentIds.add(grade.studentId.toString()));
+
+    if (allStudentIds.size === 0) {
       return [];
     }
 
-    const studentIds = Array.from(
-      new Set(grades.map((grade) => grade.studentId.toString())),
+    const students = await this.usersService.findManyByIds(Array.from(allStudentIds));
+    const studentsById = new Map(
+      students.map((student) => [student._id.toString(), student]),
     );
-    const students = await this.usersService.findManyByIds(studentIds);
-    const studentsById = new Map(students.map((student) => [student._id.toString(), student]));
 
-    return grades.map((grade) => ({
-      ...grade,
-      student: studentsById.get(grade.studentId.toString()) ?? null,
-    }));
+    return Array.from(allStudentIds)
+      .sort((a, b) => {
+        const studentA = studentsById.get(a);
+        const studentB = studentsById.get(b);
+        if (studentA?.name && studentB?.name) {
+          return studentA.name.localeCompare(studentB.name);
+        }
+        if (studentA?.name) return -1;
+        if (studentB?.name) return 1;
+        return a.localeCompare(b);
+      })
+      .map((studentId) => {
+        const grade = gradeByStudentId.get(studentId) ?? null;
+        return {
+          studentId,
+          student: studentsById.get(studentId) ?? null,
+          enrollment: enrollmentByStudentId.get(studentId) ?? null,
+          status: grade?.status ?? GradeStatus.Pending,
+          grade,
+        };
+      });
   }
 
   async listGradesForStudent(studentId: string) {
@@ -198,10 +240,46 @@ export class GradesService {
       gradeMap.set(String(grade.assignmentId), grade);
     });
 
+    const uniqueClassIds = Array.from(
+      new Set(classIds.map((classId) => classId.toString())),
+    );
+
+    const classes = await this.classModel
+      .find({ _id: { $in: uniqueClassIds } })
+      .lean()
+      .exec();
+
+    const classById = new Map(
+      classes.map((classEntity) => [classEntity._id.toString(), classEntity]),
+    );
+
+    const instructorIds = Array.from(
+      new Set(
+        classes
+          .flatMap((classEntity) => classEntity.instructorIds ?? [])
+          .map((id) => id?.toString())
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+
+    const instructors = instructorIds.length
+      ? await this.usersService.findManyByIds(instructorIds)
+      : [];
+    const instructorsById = new Map(
+      instructors.map((instructor) => [instructor._id.toString(), instructor]),
+    );
+
     return assignments
       .sort((a, b) => a.dueAt.getTime() - b.dueAt.getTime())
       .map((assignment) => {
         const grade = gradeMap.get(String(assignment._id)) ?? null;
+        const classEntity = classById.get(String(assignment.classId));
+        const primaryInstructorId = classEntity?.instructorIds?.[0]
+          ? classEntity.instructorIds[0].toString()
+          : null;
+        const primaryInstructor = primaryInstructorId
+          ? instructorsById.get(primaryInstructorId) ?? null
+          : null;
         return {
           assignmentId: String(assignment._id),
           classId: String(assignment.classId),
@@ -213,6 +291,20 @@ export class GradesService {
           maxPoints: assignment.maxPoints,
           status: grade ? grade.status : GradeStatus.Pending,
           grade,
+          class: classEntity
+            ? {
+                classId: classEntity._id.toString(),
+                title: classEntity.title,
+                code: classEntity.code,
+                primaryInstructor: primaryInstructor
+                  ? {
+                      id: primaryInstructor._id.toString(),
+                      name: primaryInstructor.name,
+                      email: primaryInstructor.email,
+                    }
+                  : null,
+              }
+            : null,
         };
       });
   }


### PR DESCRIPTION
## Summary
- enforce instructor-specific guards across class enrollment, assignment authoring, and grade actions
- centralize instructor access checks in the classes service to reuse from assignments and grades flows
- document the end-to-end teacher and student journeys for clarity

## Testing
- npm --prefix server test

------
https://chatgpt.com/codex/tasks/task_e_68dbde68de988320ae5440c371e40dd2